### PR TITLE
Implement admin and superadmin routes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+.env

--- a/README.md
+++ b/README.md
@@ -1,1 +1,34 @@
 # HRM
+
+A minimal Human Resource Management (HRM) skeleton using **FastAPI** and **PostgreSQL**.
+
+## Structure
+
+- `hrm/` – main package
+  - `main.py` – FastAPI application entry point
+  - `database.py` – SQLAlchemy session and engine
+  - `config.py` – application settings
+  - `features/` – individual feature modules
+    - `employees/`
+    - `payroll/`
+    - `attendance/`
+    - `performance/`
+    - `admin/` – admin dashboard
+    - `superadmin/` – superadmin dashboard
+  - `ai/` – placeholder for AI utilities
+
+## Running
+
+Install dependencies and start the server:
+
+```bash
+pip install -r requirements.txt
+uvicorn hrm.main:app --reload
+```
+
+The application currently exposes placeholder endpoints for each feature.
+
+### Role Simulation
+
+Use the `X-Role` HTTP header to simulate different user roles when calling the
+API. Supported roles are `user`, `admin`, and `superadmin`.

--- a/hrm/__init__.py
+++ b/hrm/__init__.py
@@ -1,0 +1,5 @@
+"""HRM package initialization."""
+
+from .main import create_app
+
+__all__ = ["create_app"]

--- a/hrm/ai/__init__.py
+++ b/hrm/ai/__init__.py
@@ -1,0 +1,5 @@
+"""AI utilities package."""
+
+from .engine import AIEvaluator
+
+__all__ = ["AIEvaluator"]

--- a/hrm/ai/engine.py
+++ b/hrm/ai/engine.py
@@ -1,0 +1,9 @@
+"""Placeholder for AI-related utilities."""
+
+
+class AIEvaluator:
+    """Simple AI evaluator placeholder."""
+
+    def evaluate(self, text: str) -> str:
+        """Return a simple evaluation string."""
+        return f"Evaluation for: {text}"

--- a/hrm/config.py
+++ b/hrm/config.py
@@ -1,0 +1,13 @@
+"""Configuration management for HRM."""
+
+import os
+from pydantic import BaseSettings
+
+
+class Settings(BaseSettings):
+    """Base settings for the application."""
+
+    database_url: str = os.getenv("DATABASE_URL", "postgresql://user:password@localhost/hrm")
+
+
+settings = Settings()

--- a/hrm/database.py
+++ b/hrm/database.py
@@ -1,0 +1,18 @@
+"""Database utilities using SQLAlchemy."""
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from .config import settings
+
+engine = create_engine(settings.database_url, echo=False, future=True)
+SessionLocal = sessionmaker(bind=engine)
+
+
+def get_db():
+    """Yield a database session."""
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/hrm/features/__init__.py
+++ b/hrm/features/__init__.py
@@ -1,0 +1,1 @@
+"""Feature modules for the HRM package."""

--- a/hrm/features/admin/__init__.py
+++ b/hrm/features/admin/__init__.py
@@ -1,0 +1,1 @@
+"""Admin feature module."""

--- a/hrm/features/admin/routes.py
+++ b/hrm/features/admin/routes.py
@@ -1,0 +1,13 @@
+"""Admin feature endpoints."""
+
+from fastapi import APIRouter, Depends
+
+from ...security import admin_required, User
+
+router = APIRouter()
+
+
+@router.get("/dashboard")
+async def admin_dashboard(current_user: User = Depends(admin_required)):
+    """Simple admin dashboard placeholder."""
+    return {"message": f"Admin dashboard for {current_user.role}"}

--- a/hrm/features/attendance/__init__.py
+++ b/hrm/features/attendance/__init__.py
@@ -1,0 +1,1 @@
+"""Attendance feature package."""

--- a/hrm/features/attendance/routes.py
+++ b/hrm/features/attendance/routes.py
@@ -1,0 +1,11 @@
+"""Attendance feature endpoints."""
+
+from fastapi import APIRouter
+
+router = APIRouter()
+
+
+@router.get("/")
+async def list_attendance():
+    """List attendance records placeholder."""
+    return {"attendance": []}

--- a/hrm/features/employees/__init__.py
+++ b/hrm/features/employees/__init__.py
@@ -1,0 +1,1 @@
+"""Employees feature package."""

--- a/hrm/features/employees/routes.py
+++ b/hrm/features/employees/routes.py
@@ -1,0 +1,11 @@
+"""Employee feature endpoints."""
+
+from fastapi import APIRouter
+
+router = APIRouter()
+
+
+@router.get("/")
+async def list_employees():
+    """List employees placeholder."""
+    return {"employees": []}

--- a/hrm/features/payroll/__init__.py
+++ b/hrm/features/payroll/__init__.py
@@ -1,0 +1,1 @@
+"""Payroll feature package."""

--- a/hrm/features/payroll/routes.py
+++ b/hrm/features/payroll/routes.py
@@ -1,0 +1,11 @@
+"""Payroll feature endpoints."""
+
+from fastapi import APIRouter
+
+router = APIRouter()
+
+
+@router.get("/")
+async def list_payroll():
+    """List payroll records placeholder."""
+    return {"payroll": []}

--- a/hrm/features/performance/__init__.py
+++ b/hrm/features/performance/__init__.py
@@ -1,0 +1,1 @@
+"""Performance feature package."""

--- a/hrm/features/performance/routes.py
+++ b/hrm/features/performance/routes.py
@@ -1,0 +1,11 @@
+"""Performance feature endpoints."""
+
+from fastapi import APIRouter
+
+router = APIRouter()
+
+
+@router.get("/")
+async def list_performance():
+    """List performance records placeholder."""
+    return {"performance": []}

--- a/hrm/features/superadmin/__init__.py
+++ b/hrm/features/superadmin/__init__.py
@@ -1,0 +1,1 @@
+"""Superadmin feature module."""

--- a/hrm/features/superadmin/routes.py
+++ b/hrm/features/superadmin/routes.py
@@ -1,0 +1,13 @@
+"""Superadmin feature endpoints."""
+
+from fastapi import APIRouter, Depends
+
+from ...security import superadmin_required, User
+
+router = APIRouter()
+
+
+@router.get("/dashboard")
+async def superadmin_dashboard(current_user: User = Depends(superadmin_required)):
+    """Simple superadmin dashboard placeholder."""
+    return {"message": "Superadmin dashboard"}

--- a/hrm/main.py
+++ b/hrm/main.py
@@ -1,0 +1,25 @@
+"""Main FastAPI application."""
+
+from fastapi import FastAPI
+
+from .features.employees.routes import router as employees_router
+from .features.payroll.routes import router as payroll_router
+from .features.attendance.routes import router as attendance_router
+from .features.performance.routes import router as performance_router
+from .features.admin.routes import router as admin_router
+from .features.superadmin.routes import router as superadmin_router
+
+
+def create_app() -> FastAPI:
+    """Create and configure the FastAPI app."""
+    app = FastAPI(title="HRM")
+    app.include_router(employees_router, prefix="/employees")
+    app.include_router(payroll_router, prefix="/payroll")
+    app.include_router(attendance_router, prefix="/attendance")
+    app.include_router(performance_router, prefix="/performance")
+    app.include_router(admin_router, prefix="/admin")
+    app.include_router(superadmin_router, prefix="/superadmin")
+    return app
+
+
+app = create_app()

--- a/hrm/security.py
+++ b/hrm/security.py
@@ -1,0 +1,30 @@
+"""Simple role-based security utilities."""
+
+from fastapi import Header, HTTPException, status, Depends
+from pydantic import BaseModel
+
+
+class User(BaseModel):
+    """Authenticated user representation."""
+
+    username: str = "placeholder"
+    role: str = "user"
+
+
+def get_current_user(x_role: str = Header(default="user")) -> User:
+    """Retrieve the current user from the X-Role header."""
+    return User(role=x_role)
+
+
+def admin_required(user: User = Depends(get_current_user)) -> User:
+    """Ensure the user has admin or superadmin role."""
+    if user.role not in ("admin", "superadmin"):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Admin privileges required")
+    return user
+
+
+def superadmin_required(user: User = Depends(get_current_user)) -> User:
+    """Ensure the user has superadmin role."""
+    if user.role != "superadmin":
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Superadmin privileges required")
+    return user

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+fastapi
+uvicorn
+sqlalchemy
+pydantic
+psycopg2-binary


### PR DESCRIPTION
## Summary
- add simple role-based security helper
- create admin and superadmin feature modules
- register new routers in main app
- document role simulation in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6856845acae48324a507fd28c52caaa0